### PR TITLE
TMS-1013: Add event weekly entry dates to event partial

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1013: Add event weekly entry dates to event partial
+
 ## [1.2.1] - 2024-02-01
 
 - TMS-980: Add redipress_include_search to include component contents in search results

--- a/partials/views/single-dynamic-event/single-dynamic-event-info.dust
+++ b/partials/views/single-dynamic-event/single-dynamic-event-info.dust
@@ -4,11 +4,21 @@
             {>"views/single-dynamic-event/single-dynamic-event-group-title" title=event.normalized.date_title template_classes=template_classes.info_group_title icon="date" /}
 
             <div class="info-group__description has-text-small has-text-small pt-1 pr-8 pb-4 pl-9">
-                {#event.normalized.dates}
-                    <div>
-                        {date|html}
-                    </div>
+                {?event.normalized.dates}
+                    {#event.normalized.dates}
+                        <div>
+                            {date|html}
+                        </div>
+                    {/event.normalized.dates}
                 {/event.normalized.dates}
+
+                {?event.normalized.entries}
+                    {#event.normalized.entries}
+                        <div>
+                            {date|attr}
+                        </div>
+                    {/event.normalized.entries}
+                {/event.normalized.entries}
             </div>
         </div>
     {/event.normalized.date}


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1013 Tapahtumaintegraatio: viikkokalenteri-tapahtumat
Task: https://hiondigital.atlassian.net/browse/TMS-1013

## Description
Add event weekly entry dates to single event partial

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
